### PR TITLE
Use `chrono::OutOfRangeError`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ name = "float_duration"
 path = "src/lib.rs"
 
 [dependencies]
-chrono = { version = "0.4.0", optional = true }
+chrono = { version = "0.4.23", optional = true }
 time = { version = "0.1.37", optional = true }
 approx = { version = "0.1.1", optional = true }
 serde = { version = "^1.0", optional = true }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,7 +3,7 @@ use std::error::Error;
 use std::fmt;
 
 #[cfg(feature = "chrono")]
-use time;
+use chrono;
 
 #[derive(Debug, Clone, Default)]
 pub struct OutOfRangeError {}
@@ -27,8 +27,8 @@ impl fmt::Display for OutOfRangeError {
 }
 
 #[cfg(feature = "chrono")]
-impl From<time::OutOfRangeError> for OutOfRangeError {
-    fn from(_: time::OutOfRangeError) -> OutOfRangeError {
+impl From<chrono::OutOfRangeError> for OutOfRangeError {
+    fn from(_: chrono::OutOfRangeError) -> OutOfRangeError {
         OutOfRangeError {}
     }
 }


### PR DESCRIPTION
Since version 0.4.23 chrono has its own `OutOfRangeError`.
It is currently a re-export of `time::OutOfRangeError`, but we would like to break that in chrono in a minor release.

The reason is that there is a security advisory against time 0.1 that bugs _many_ downstream users of chrono, while only a handful of crates, including yours, rely on the types in time 0.1 and chrono being the same.

Will you please accept this PR, and maybe release a new minor version?